### PR TITLE
modifying git grep command to prevent ambiguous argument error

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -106,7 +106,7 @@ git_grep() {
   local options="$1"; shift
   local files=$@ combined_patterns=$(load_combined_patterns)
   [ -z "${combined_patterns}" ] && return 1
-  GREP_OPTIONS= LC_ALL=C git grep -nwHEI ${options} "${combined_patterns}" $files
+  GREP_OPTIONS= LC_ALL=C git grep -nwHEI ${options} "${combined_patterns}" -- $files
 }
 
 # Performs a regular grep, taking into account patterns and recursion.


### PR DESCRIPTION
When trying to commit more than two files, I was getting an error...

Example:
$ git commit -m "test"
fatal: ambiguous argument 'file1 file2': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

Adding the "--" before the $files variable shouldn't break anything, and should prevent the ambiguous argument error.

Currently working on a stable archlinux, git version 2.10.2